### PR TITLE
chore(Brainstorm) : Bump ubuntu version to 24.04

### DIFF
--- a/apps/brainstorm/Dockerfile
+++ b/apps/brainstorm/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 SHELL ["/bin/bash", "-xe", "-o", "pipefail", "-c"]
 
 ARG APP_NAME
@@ -48,7 +48,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get autoremove -y --purge
 
 ENV APP_SPECIAL="no"
-ENV APP_CMD="/apps/${APP_NAME}/install/brainstorm3/bin/R2022b/brainstorm3.command /usr/local/MATLAB/MATLAB_Runtime/R2022b"
+ENV APP_CMD="/apps/${APP_NAME}/install/brainstorm3/bin/R2023a/brainstorm3.command /usr/local/MATLAB/MATLAB_Runtime/R2023a"
 ENV PROCESS_NAME="brainstorm3.jar"
 ENV APP_DATA_DIR_ARRAY="brainstorm_db .brainstorm"
 #ENV APP_DATA_DIR_ARRAY="brainstorm_db .brainstorm .mcrCache9.8"

--- a/apps/brainstorm/build.sh
+++ b/apps/brainstorm/build.sh
@@ -18,7 +18,7 @@ exec docker buildx build \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
-    --build-arg "MAT_VERSION=R2022b" \
-    --build-arg "MAT_UPDATE=7" \
+    --build-arg "MAT_VERSION=R2023a" \
+    --build-arg "MAT_UPDATE=6" \
     --output=$OUTPUT \
     .

--- a/apps/brainstorm/scripts/create-user.sh
+++ b/apps/brainstorm/scripts/create-user.sh
@@ -26,7 +26,7 @@ if [ $? -eq 0 ]; then
   echo "$HIP_USER already exists."
   exit 0
 else
-  useradd --create-home --shell /bin/bash $HIP_USER --uid 1000
+  useradd --create-home --shell /bin/bash $HIP_USER --uid 1001
   if [ $? -eq 0 ]; then
     echo "done."
   else


### PR DESCRIPTION
Use of uid 1001 per the modification to xpra
New default matlab runtime for brainstorm is R2023a , Update 6 