### PR TITLE
chore(server): bump Xpra to 6.1.3

### DIFF
--- a/server/build.sh
+++ b/server/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 APP_NAME="xpra-server"
-APP_VERSION="6.1.2"
+APP_VERSION="6.1.3"
 PKG_REL="1"
 
 # If the APP_VERSION is bumped, reset the PKG_REL
@@ -11,7 +11,7 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 # See: https://github.com/VirtualGL/virtualgl/releases
 VIRTUALGL_VERSION=3.1.1
 # See: https://xpra.org/dists/noble/main/binary-amd64/
-XPRA_VERSION="${APP_VERSION}-r1"
+XPRA_VERSION="${APP_VERSION}-r0"
 XPRA_HTML5_VERSION="15.1-r0"
 
 REGISTRY="${REGISTRY:=registry.build.chorus-tre.local}"

--- a/server/build.sh
+++ b/server/build.sh
@@ -12,7 +12,7 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 VIRTUALGL_VERSION=3.1.1
 # See: https://xpra.org/dists/noble/main/binary-amd64/
 XPRA_VERSION="${APP_VERSION}-r0"
-XPRA_HTML5_VERSION="15.1-r0"
+XPRA_HTML5_VERSION="16.1-r0"
 
 REGISTRY="${REGISTRY:=registry.build.chorus-tre.local}"
 


### PR DESCRIPTION
https://github.com/Xpra-org/xpra/releases/tag/v6.1.3

<img width="1092" alt="Capture d’écran 2024-09-30 à 10 59 21" src="https://github.com/user-attachments/assets/f0124da7-2134-4a95-9d94-d17481ba261c">
