### PR TITLE
fix(core) : no upgrade in the core scripts to prevents nuking installations done via apt

### DIFF
--- a/apps/vscode/build.sh
+++ b/apps/vscode/build.sh
@@ -4,7 +4,7 @@ set -e
 
 APP_NAME="vscode"
 APP_VERSION=1.93.1
-PKG_REL="2"
+PKG_REL="3"
 
 # If the APP_VERSION is bumped, reset the PKG_REL
 # otherwhise, please bump the PKG_REL on any changes.

--- a/core/utilities/chorus-utils.sh
+++ b/core/utilities/chorus-utils.sh
@@ -16,3 +16,4 @@ echo "===> Creating directory /docker-entrypoint.d"
 mkdir /docker-entrypoint.d
 
 apt-get -qq autoremove -y --purge
+rm -rf /var/lib/apt/lists/*

--- a/core/utilities/chorus-utils.sh
+++ b/core/utilities/chorus-utils.sh
@@ -7,7 +7,6 @@ echo "========================================================================"
 echo ""
 
 apt-get -qq update && \
-apt-get -qq upgrade -y && \
 apt-get install -qq --no-install-recommends -y curl ca-certificates gnupg && \
 
 script_dir=$(dirname "$0")


### PR DESCRIPTION
Because without that, as soon as the version of the script becomes N-1 it tries to upgrade and then kaboom