### PR TITLE
chore(server): bump Xpra to 6.2

### DIFF
--- a/server/Dockerfile.ubuntu-main
+++ b/server/Dockerfile.ubuntu-main
@@ -65,7 +65,6 @@ RUN --mount=type=cache,target=/var/cache/apt \
         lsb-release \
         software-properties-common && \
     apt-get autoremove -y --purge && \
-    chmod 644 /etc/xpra/ssl-cert.pem && \
     # create the xpra user
     useradd --create-home --shell /bin/bash xpra --gid xpra --uid 1001
 

--- a/server/build.sh
+++ b/server/build.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 APP_NAME="xpra-server"
-APP_VERSION="6.1.3"
-PKG_REL="2"
+APP_VERSION="6.2.0"
+PKG_REL="1"
 
 # If the APP_VERSION is bumped, reset the PKG_REL
 # otherwhise, please bump the PKG_REL on any changes.
@@ -12,7 +12,7 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 VIRTUALGL_VERSION=3.1.1
 # See: https://xpra.org/dists/noble/main/binary-amd64/
 XPRA_VERSION="${APP_VERSION}-r0"
-XPRA_HTML5_VERSION="16.1-r0"
+XPRA_HTML5_VERSION="16.2-r0"
 
 REGISTRY="${REGISTRY:=registry.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"

--- a/server/config/xpra.conf
+++ b/server/config/xpra.conf
@@ -4,6 +4,8 @@ html=on
 # xhost + allows to connect from everywhere
 start=xhost +
 
+start-new-commands=no
+
 # disable bell
 bell=no
 # disable printing
@@ -26,11 +28,6 @@ dbus-launch=no
 
 # disable systemd as it is not available within docker
 systemd-run=no
-
-# use SSL certificate
-ssl-cert=/etc/xpra/ssl-cert.pem
-# disable client certificate authentication
-ssl-client-verify-mode=none
 
 # enable system-tray
 system-tray=yes


### PR DESCRIPTION
https://github.com/Xpra-org/xpra/releases/tag/v6.2

<img width="1062" alt="Capture d’écran 2024-10-14 à 18 16 24" src="https://github.com/user-attachments/assets/5749a1b8-f1a9-4830-8934-c84b7e16068e">
