### PR TITLE
fix(apps): harmonize and docker cache

### DIFF
--- a/apps/arx/build.sh
+++ b/apps/arx/build.sh
@@ -12,9 +12,30 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
+CACHE="${CACHE:=cache}"
+BUILDER_NAME="docker-container"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
+
+if [ "$OUTPUT" = "type=registry" ]; then
+    CACHE_FROM="\
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION} \
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest"
+
+    CACHE_TO="\
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION},mode=max,image-manifest=true \
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest,mode=max,image-manifest=true"
+else
+    mkdir -p /tmp/.buildx-cache  # Ensure cache directory exists
+    CACHE_FROM="--cache-from=type=local,src=/tmp/.buildx-cache"
+    CACHE_TO="--cache-to=type=local,dest=/tmp/.buildx-cache"
+fi
+
+# Check if the builder exists
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
+fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
@@ -23,10 +44,13 @@ trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
+    --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     --output=$OUTPUT \
     .

--- a/apps/bidsificator/build.sh
+++ b/apps/bidsificator/build.sh
@@ -17,9 +17,9 @@ REPOSITORY="${REPOSITORY:=apps}"
 OUTPUT="type=${OUTPUT:-docker}"
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
-BUILDKIT_PROGRESS=plain
+
 cp -r ../../core ./core
-trap "rm -rf core" EXIT
+trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \

--- a/apps/bidsificator/build.sh
+++ b/apps/bidsificator/build.sh
@@ -12,9 +12,30 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
+CACHE="${CACHE:=cache}"
+BUILDER_NAME="docker-container"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
+
+if [ "$OUTPUT" = "type=registry" ]; then
+    CACHE_FROM="\
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION} \
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest"
+
+    CACHE_TO="\
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION},mode=max,image-manifest=true \
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest,mode=max,image-manifest=true"
+else
+    mkdir -p /tmp/.buildx-cache  # Ensure cache directory exists
+    CACHE_FROM="--cache-from=type=local,src=/tmp/.buildx-cache"
+    CACHE_TO="--cache-to=type=local,dest=/tmp/.buildx-cache"
+fi
+
+# Check if the builder exists
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
+fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
@@ -23,10 +44,13 @@ trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
+    --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     --output=$OUTPUT \
     .

--- a/apps/brainstorm/build.sh
+++ b/apps/brainstorm/build.sh
@@ -19,7 +19,7 @@ OUTPUT="type=${OUTPUT:-docker}"
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
 cp -r ../../core ./core
-trap "rm -rf core" EXIT
+trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \

--- a/apps/didata/Dockerfile
+++ b/apps/didata/Dockerfile
@@ -37,11 +37,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libatomic1 \
         xvfb && \
     # Download and install NW.js
-    wget https://dl.nwjs.io/v0.94.0/nwjs-v0.94.0-linux-x64.tar.gz && \
-    tar -xzf nwjs-v0.94.0-linux-x64.tar.gz && \
-    mv nwjs-v0.94.0-linux-x64 /opt/nwjs && \
+    wget https://dl.nwjs.io/v${APP_VERSION}/nwjs-v${APP_VERSION}-linux-x64.tar.gz && \
+    tar -xzf nwjs-v${APP_VERSION}-linux-x64.tar.gz && \
+    mv nwjs-v${APP_VERSION}-linux-x64 /opt/nwjs && \
     ln -s /opt/nwjs/nw /usr/local/bin/nw && \
-    rm nwjs-v0.94.0-linux-x64.tar.gz && \
+    rm nwjs-v${APP_VERSION}-linux-x64.tar.gz && \
     apt-get remove -y --purge wget gpg && \
     apt-get autoremove -y --purge
 

--- a/apps/didata/build.sh
+++ b/apps/didata/build.sh
@@ -3,7 +3,7 @@
 set -e
 
 APP_NAME="didata"
-APP_VERSION="0.0.1"
+APP_VERSION="0.94.0"
 PKG_REL="1"
 
 # If the APP_VERSION is bumped, reset the PKG_REL
@@ -12,9 +12,30 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
+CACHE="${CACHE:=cache}"
+BUILDER_NAME="docker-container"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
+
+if [ "$OUTPUT" = "type=registry" ]; then
+    CACHE_FROM="\
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION} \
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest"
+
+    CACHE_TO="\
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION},mode=max,image-manifest=true \
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest,mode=max,image-manifest=true"
+else
+    mkdir -p /tmp/.buildx-cache  # Ensure cache directory exists
+    CACHE_FROM="--cache-from=type=local,src=/tmp/.buildx-cache"
+    CACHE_TO="--cache-to=type=local,dest=/tmp/.buildx-cache"
+fi
+
+# Check if the builder exists
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
+fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
@@ -23,10 +44,13 @@ trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
+    --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     --output=$OUTPUT \
     .

--- a/apps/didata/build.sh
+++ b/apps/didata/build.sh
@@ -10,7 +10,7 @@ PKG_REL="1"
 # otherwhise, please bump the PKG_REL on any changes.
 VERSION="${APP_VERSION}-${PKG_REL}"
 
-REGISTRY="${REGISTRY:=registry.build.chorus-tre.local}"
+REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
 
 # Use `registry` to build and push

--- a/apps/freesurfer/build.sh
+++ b/apps/freesurfer/build.sh
@@ -19,7 +19,7 @@ OUTPUT="type=${OUTPUT:-docker}"
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
 cp -r ../../core ./core
-trap "rm -rf core" EXIT
+trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \

--- a/apps/freesurfer/build.sh
+++ b/apps/freesurfer/build.sh
@@ -12,9 +12,30 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
+CACHE="${CACHE:=cache}"
+BUILDER_NAME="docker-container"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
+
+if [ "$OUTPUT" = "type=registry" ]; then
+    CACHE_FROM="\
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION} \
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest"
+
+    CACHE_TO="\
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION},mode=max,image-manifest=true \
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest,mode=max,image-manifest=true"
+else
+    mkdir -p /tmp/.buildx-cache  # Ensure cache directory exists
+    CACHE_FROM="--cache-from=type=local,src=/tmp/.buildx-cache"
+    CACHE_TO="--cache-to=type=local,dest=/tmp/.buildx-cache"
+fi
+
+# Check if the builder exists
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
+fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
@@ -23,10 +44,13 @@ trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
+    --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     --output=$OUTPUT \
     .

--- a/apps/fsl/build.sh
+++ b/apps/fsl/build.sh
@@ -12,9 +12,30 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
+CACHE="${CACHE:=cache}"
+BUILDER_NAME="docker-container"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
+
+if [ "$OUTPUT" = "type=registry" ]; then
+    CACHE_FROM="\
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION} \
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest"
+
+    CACHE_TO="\
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION},mode=max,image-manifest=true \
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest,mode=max,image-manifest=true"
+else
+    mkdir -p /tmp/.buildx-cache  # Ensure cache directory exists
+    CACHE_FROM="--cache-from=type=local,src=/tmp/.buildx-cache"
+    CACHE_TO="--cache-to=type=local,dest=/tmp/.buildx-cache"
+fi
+
+# Check if the builder exists
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
+fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
@@ -23,10 +44,13 @@ trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
+    --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     --output=$OUTPUT \
     .

--- a/apps/itksnap/build.sh
+++ b/apps/itksnap/build.sh
@@ -14,9 +14,30 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
+CACHE="${CACHE:=cache}"
+BUILDER_NAME="docker-container"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
+
+if [ "$OUTPUT" = "type=registry" ]; then
+    CACHE_FROM="\
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION} \
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest"
+
+    CACHE_TO="\
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION},mode=max,image-manifest=true \
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest,mode=max,image-manifest=true"
+else
+    mkdir -p /tmp/.buildx-cache  # Ensure cache directory exists
+    CACHE_FROM="--cache-from=type=local,src=/tmp/.buildx-cache"
+    CACHE_TO="--cache-to=type=local,dest=/tmp/.buildx-cache"
+fi
+
+# Check if the builder exists
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
+fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
@@ -25,6 +46,7 @@ trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
+    --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
@@ -32,4 +54,6 @@ docker buildx build \
     --build-arg "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_VERSION_FULL=${APP_VERSION_FULL}" \
     --output=$OUTPUT \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     .

--- a/apps/itksnap/build.sh
+++ b/apps/itksnap/build.sh
@@ -8,22 +8,24 @@ APP_VERSION="4.2.0"
 APP_VERSION_FULL="${APP_VERSION}-20240422"
 PKG_REL="1"
 
+# If the APP_VERSION is bumped, reset the PKG_REL
+# otherwhise, please bump the PKG_REL on any changes.
 VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
+REPOSITORY="${REPOSITORY:=apps}"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
-cp -rp ../../core .
-trap "rm -rf core" EXIT
+cp -r ../../core ./core
+trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
-    -t ${REGISTRY}/${APP_NAME} \
-    -t ${REGISTRY}/${APP_NAME}:${VERSION} \
+    -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \

--- a/apps/jupyterlab/build.sh
+++ b/apps/jupyterlab/build.sh
@@ -8,11 +8,14 @@ APP_VERSION="4.2.5"
 APP_VERSION_FULL="${APP_VERSION}-1"
 PKG_REL="1"
 
+# If the APP_VERSION is bumped, reset the PKG_REL
+# otherwhise, please bump the PKG_REL on any changes.
+VERSION="${APP_VERSION}-${PKG_REL}"
+
 # https://conda-forge.org/miniforge/
 # https://github.com/conda-forge/miniforge/releases
 MINIFORGE3_VERSION="24.9.0-0"
 
-VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
@@ -23,7 +26,7 @@ OUTPUT="type=${OUTPUT:-docker}"
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
 cp -r ../../core ./core
-trap "rm -rf core" EXIT
+trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \

--- a/apps/jupyterlab/build.sh
+++ b/apps/jupyterlab/build.sh
@@ -16,12 +16,32 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 # https://github.com/conda-forge/miniforge/releases
 MINIFORGE3_VERSION="24.9.0-0"
 
-
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
+CACHE="${CACHE:=cache}"
+BUILDER_NAME="docker-container"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
+
+if [ "$OUTPUT" = "type=registry" ]; then
+    CACHE_FROM="\
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION} \
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest"
+
+    CACHE_TO="\
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION},mode=max,image-manifest=true \
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest,mode=max,image-manifest=true"
+else
+    mkdir -p /tmp/.buildx-cache  # Ensure cache directory exists
+    CACHE_FROM="--cache-from=type=local,src=/tmp/.buildx-cache"
+    CACHE_TO="--cache-to=type=local,dest=/tmp/.buildx-cache"
+fi
+
+# Check if the builder exists
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
+fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
@@ -30,6 +50,7 @@ trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
+    --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
@@ -38,4 +59,6 @@ docker buildx build \
     --build-arg "APP_VERSION_FULL=${APP_VERSION_FULL}" \
     --build-arg "MINIFORGE3_VERSION=${MINIFORGE3_VERSION}" \
     --output=$OUTPUT \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     .

--- a/apps/localizer/build.sh
+++ b/apps/localizer/build.sh
@@ -12,9 +12,30 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
+CACHE="${CACHE:=cache}"
+BUILDER_NAME="docker-container"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
+
+if [ "$OUTPUT" = "type=registry" ]; then
+    CACHE_FROM="\
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION} \
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest"
+
+    CACHE_TO="\
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION},mode=max,image-manifest=true \
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest,mode=max,image-manifest=true"
+else
+    mkdir -p /tmp/.buildx-cache  # Ensure cache directory exists
+    CACHE_FROM="--cache-from=type=local,src=/tmp/.buildx-cache"
+    CACHE_TO="--cache-to=type=local,dest=/tmp/.buildx-cache"
+fi
+
+# Check if the builder exists
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
+fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
@@ -23,10 +44,13 @@ trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
+    --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
     --output=$OUTPUT \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     .

--- a/apps/rstudio/build.sh
+++ b/apps/rstudio/build.sh
@@ -12,9 +12,30 @@ VERSION="${APP_VERSION}-${PKG_REL}"
 
 REGISTRY="${REGISTRY:=harbor.build.chorus-tre.local}"
 REPOSITORY="${REPOSITORY:=apps}"
+CACHE="${CACHE:=cache}"
+BUILDER_NAME="docker-container"
 
 # Use `registry` to build and push
 OUTPUT="type=${OUTPUT:-docker}"
+
+if [ "$OUTPUT" = "type=registry" ]; then
+    CACHE_FROM="\
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION} \
+        --cache-from=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest"
+
+    CACHE_TO="\
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:${VERSION},mode=max,image-manifest=true \
+        --cache-to=type=registry,ref=${REGISTRY}/${CACHE}/${APP_NAME}-${CACHE}:latest,mode=max,image-manifest=true"
+else
+    mkdir -p /tmp/.buildx-cache  # Ensure cache directory exists
+    CACHE_FROM="--cache-from=type=local,src=/tmp/.buildx-cache"
+    CACHE_TO="--cache-to=type=local,dest=/tmp/.buildx-cache"
+fi
+
+# Check if the builder exists
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
+fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
@@ -23,10 +44,13 @@ trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \
+    --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \
     --label "APP_NAME=${APP_NAME}" \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     --output=$OUTPUT \
     .

--- a/apps/sciterminal/build.sh
+++ b/apps/sciterminal/build.sh
@@ -6,6 +6,8 @@ APP_NAME="sciterminal"
 APP_VERSION="20241018"
 PKG_REL="1"
 
+# If the APP_VERSION is bumped, reset the PKG_REL
+# otherwhise, please bump the PKG_REL on any changes.
 VERSION="${APP_VERSION}-${PKG_REL}"
 
 # Trust me bro
@@ -24,8 +26,9 @@ REPOSITORY="${REPOSITORY:=apps}"
 OUTPUT="type=${OUTPUT:-docker}"
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
+
 cp -r ../../core ./core
-trap "rm -rf core" EXIT
+trap "rm -rf ./core" EXIT
 
 docker buildx build \
     --pull \

--- a/apps/trcanonymizer/build.sh
+++ b/apps/trcanonymizer/build.sh
@@ -28,5 +28,7 @@ docker buildx build \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     --output=$OUTPUT \
     .

--- a/apps/vscode/build.sh
+++ b/apps/vscode/build.sh
@@ -28,5 +28,7 @@ docker buildx build \
     --label "APP_VERSION=${APP_VERSION}" \
     --build-arg "APP_NAME=${APP_NAME}" \
     --build-arg "APP_VERSION=${APP_VERSION}" \
+    ${CACHE_FROM} \
+    ${CACHE_TO} \
     --output=$OUTPUT \
     .

--- a/server/build.sh
+++ b/server/build.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 APP_NAME="xpra-server"
 APP_VERSION="6.2.3"
 PKG_REL="1"


### PR DESCRIPTION
For all for `build.sh` files:
- [x] Harmonize
- [x] Add docker caching

This introduces a new version of brainstorm, it also changes the version numbering for brainstorm and didata.