### PR TITLE
fix(apps) : no need for - for buildx

### DIFF
--- a/apps/arx/build.sh
+++ b/apps/arx/build.sh
@@ -35,8 +35,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -44,7 +44,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/bidsificator/build.sh
+++ b/apps/bidsificator/build.sh
@@ -35,8 +35,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -44,7 +44,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/brainstorm/build.sh
+++ b/apps/brainstorm/build.sh
@@ -36,8 +36,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -45,7 +45,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/didata/build.sh
+++ b/apps/didata/build.sh
@@ -35,8 +35,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -44,7 +44,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/freesurfer/build.sh
+++ b/apps/freesurfer/build.sh
@@ -36,8 +36,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -45,7 +45,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/fsl/build.sh
+++ b/apps/fsl/build.sh
@@ -36,8 +36,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -45,7 +45,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/itksnap/build.sh
+++ b/apps/itksnap/build.sh
@@ -37,8 +37,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -46,7 +46,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/jupyterlab/build.sh
+++ b/apps/jupyterlab/build.sh
@@ -41,8 +41,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -50,7 +50,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/kiosk/build.sh
+++ b/apps/kiosk/build.sh
@@ -36,8 +36,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -45,7 +45,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/localizer/build.sh
+++ b/apps/localizer/build.sh
@@ -35,8 +35,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -44,7 +44,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/rstudio/build.sh
+++ b/apps/rstudio/build.sh
@@ -35,8 +35,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -44,7 +44,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/sciterminal/build.sh
+++ b/apps/sciterminal/build.sh
@@ -44,8 +44,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -53,7 +53,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/trcanonymizer/build.sh
+++ b/apps/trcanonymizer/build.sh
@@ -35,8 +35,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -44,7 +44,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/apps/vscode/build.sh
+++ b/apps/vscode/build.sh
@@ -35,8 +35,8 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
@@ -44,7 +44,7 @@ fi
 cp -r ../../core ./core
 trap "rm -rf ./core" EXIT
 
-docker-buildx build \
+docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \

--- a/core/README.md
+++ b/core/README.md
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends openssh-client
 RUN mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
 ```
 
-At the same time you need to add the flag ```--ssh default``` to the ```docker-buildx``` command in the build.sh of your app
+At the same time you need to add the flag ```--ssh default``` to the ```docker buildx``` command in the build.sh of your app
 
 **3. Add the core scripts from the CHORUS-TRE repo : we only want the core folder to limit the size of the image.**
 

--- a/server/build.sh
+++ b/server/build.sh
@@ -53,13 +53,13 @@ else
 fi
 
 # Check if the builder exists
-if ! docker-buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
-    docker-buildx create --name "${BUILDER_NAME}" --driver docker-container
+if ! docker buildx inspect "${BUILDER_NAME}" >/dev/null 2>&1; then
+    docker buildx create --name "${BUILDER_NAME}" --driver docker-container
 fi
 
 # Tip: use `BUILDKIT_PROGRESS=plain` to see more.
 
-exec docker-buildx build \
+exec docker buildx build \
     --pull \
     --builder ${BUILDER_NAME} \
     -t ${REGISTRY}/${REPOSITORY}/${APP_NAME}:${VERSION} \


### PR DESCRIPTION
There is a symlink to do when setting up **docker-buildx** on Mac in order for it to be able to run without the dash

```
mkdir -p ~/.docker/cli-plugins
ln -sfn /opt/homebrew/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx
```

and then you can run **docker buildx**