### PR TITLE
feat(apps) : Bump Freesurfer to v8

### DIFF
--- a/apps/freesurfer/Dockerfile
+++ b/apps/freesurfer/Dockerfile
@@ -12,20 +12,23 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
     apt-get update -qy && \
     apt-get install --no-install-recommends -qy \
-    curl ca-certificates language-pack-en binutils libx11-dev \
-    gettext xterm x11-apps perl make csh tcsh file bc xorg \
-    xorg-dev xserver-xorg-video-intel libncurses5 libdrm2 libegl1 \
-    libexpat1 libfontconfig1 libfreetype6 libgl1 libglib2.0-0 \
-    libglu1-mesa libglu1 libglvnd0 libglx0 libgomp1 libice6 \
-    libjpeg62 libopengl0 libpng16-16 libquadmath0 libsm6 \
-    libwayland-client0 libwayland-cursor0 libx11-6 libx11-xcb1 \
-    libxcb-icccm4 libxcb-randr0 libxcb-render-util0 libxcb-render0 libxcb-shape0 \
-    libxcb-sync1 libxcb-xfixes0 libxcb-xinerama0 libxcb-xinput0 libxext6 libxft2 \
-    libxcb-image0 libxcb-keysyms1 libxcb-xkb1 libxkbcommon-x11-0 libxkbcommon0 \
-    libxi6 libxmu6 libxrender1 libxss1 libxt6 && \
+    curl ca-certificates language-pack-en binutils \
+    libx11-dev gettext xterm x11-apps perl make csh tcsh file bc \
+    xorg xorg-dev xserver-xorg-video-intel libncurses5 libbsd0 \
+    libegl1 libexpat1 libfontconfig1 libfreetype6 libgl1 libglib2.0-0 \
+    libglu1-mesa libglvnd0 libglx0 libgomp1 libice6 libicu70 libjpeg62 \
+    libmd0 libopengl0 libpcre2-16-0 libpng16-16 libquadmath0 libsm6 \
+    libx11-6 libx11-xcb1 libxau6 libxcb-icccm4 libxcb-image0 \
+    libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render0 \
+    libxcb-shape0 libxcb-shm0 libxcb-sync1 libxcb-util1 libxcb-xfixes0 \
+    libxcb-xinerama0 libxcb-xinput0 libxcb-xkb1 libxcb1 libxdmcp6 \
+    libxext6 libxft2 libxi6 libxkbcommon-x11-0 libxkbcommon0 libxmu6 \
+    libxrender1 libxss1 libxt6 dbus-x11 libcanberra-gtk3-module libcanberra-gtk-module && \
     curl -sSO https://surfer.nmr.mgh.harvard.edu/pub/dist/freesurfer/${APP_VERSION}/freesurfer_ubuntu22-${APP_VERSION}_amd64.deb && \
     dpkg -i freesurfer_ubuntu22-${APP_VERSION}_amd64.deb && \
     rm freesurfer_ubuntu22-${APP_VERSION}_amd64.deb && \
+    mkdir -p /apps/${APP_NAME}/subjects && \
+    chown -R 1001:1001 /apps/${APP_NAME}/subjects && \
     apt-get remove -y --purge curl && \
     apt-get autoremove -y --purge
 

--- a/apps/freesurfer/build.sh
+++ b/apps/freesurfer/build.sh
@@ -3,8 +3,8 @@
 set -e
 
 APP_NAME="freesurfer"
-APP_VERSION=7.3.2
-PKG_REL="4"
+APP_VERSION=8.0.0
+PKG_REL="1"
 
 # If the APP_VERSION is bumped, reset the PKG_REL
 # otherwhise, please bump the PKG_REL on any changes.

--- a/apps/freesurfer/config/.bash_profile
+++ b/apps/freesurfer/config/.bash_profile
@@ -2,10 +2,11 @@ APP_VERSION=$(ls /usr/local/freesurfer/)
 
 export FREESURFER_HOME=/usr/local/freesurfer/${APP_VERSION}
 export FS_LICENSE=$HOME/license.txt
+export SUBJECTS_DIR=/apps/freesurfer/subjects
 
 # Create a license file
-if [ -s "$HOME/config/.env" ]; then
-    . "$HOME/config/.env"
+if [ -s "/apps/freesurfer/config/.env" ]; then
+    . "/apps/freesurfer/config/.env"
 fi
 
 echo -e "$FREESURFER_LICENSE" > "$HOME/license.txt"


### PR DESCRIPTION
We also add a default data subject folder in /apps/freesurfer . 
For now its only purpose is to validate that recon-all starts with a valid license.