### PR TITLE
fix(services): update mlflow netpols to allow DNS queries to CoreDNS

### DIFF
--- a/services/mlflow/templates/ciliumnetworkpolicy.yaml
+++ b/services/mlflow/templates/ciliumnetworkpolicy.yaml
@@ -25,12 +25,19 @@ spec:
   {{- if .Values.networkPolicy.egress }}
   {{- toYaml .Values.networkPolicy.egress | nindent 2 }}
   {{- else }}
-  # Default: allow same-namespace egress (all ports) so mlflow can reach the
-  # bundled PostgreSQL pod and any other release-local component. DNS egress is
-  # granted by the workspace-level CiliumNetworkPolicy the workbench-operator
-  # installs in this namespace, so it is not restated here.
+  # Allow same-namespace egress so mlflow can reach the bundled PostgreSQL pod.
   - toEndpoints:
     - matchLabels:
         k8s:io.kubernetes.pod.namespace: {{ .Release.Namespace }}
+  # Allow DNS queries to CoreDNS in kube-system only.
+  - toEndpoints:
+    - matchLabels:
+        k8s:io.kubernetes.pod.namespace: kube-system
+    toPorts:
+    - ports:
+      - port: "53"
+        protocol: UDP
+      - port: "53"
+        protocol: TCP
   {{- end }}
 {{- end }}

--- a/services/mlflow/templates/networkpolicy.yaml
+++ b/services/mlflow/templates/networkpolicy.yaml
@@ -29,13 +29,20 @@ spec:
   {{- if .Values.networkPolicy.egress }}
   {{- toYaml .Values.networkPolicy.egress | nindent 2 }}
   {{- else }}
-  # Default: allow same-namespace egress (all ports) so mlflow can reach the
-  # bundled PostgreSQL pod and any other release-local component. DNS egress is
-  # granted by the workspace-level CiliumNetworkPolicy the workbench-operator
-  # installs in this namespace, so it is not restated here.
+  # Allow same-namespace egress so mlflow can reach the bundled PostgreSQL pod.
   - to:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  # Allow DNS queries to CoreDNS in kube-system only.
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
   {{- end }}
 {{- end }}


### PR DESCRIPTION
This pull request updates the default egress rules in the `mlflow` network policy templates to explicitly allow DNS queries only to CoreDNS in the `kube-system` namespace, tightening the previous default which relied on broader workspace-level policies. The changes clarify and restrict DNS egress, improving security and transparency.

**Network policy egress rule updates:**

* In `ciliumnetworkpolicy.yaml`, replaced the comment and default egress rule to explicitly allow DNS queries (TCP/UDP port 53) only to pods in the `kube-system` namespace, in addition to allowing same-namespace egress for PostgreSQL access.
* In `networkpolicy.yaml`, similarly updated the default egress rule to allow DNS queries (TCP/UDP port 53) only to the `kube-system` namespace, alongside same-namespace egress.